### PR TITLE
fix: libgit2 CMake configuration install libgit2 v1.8.4 .. failed

### DIFF
--- a/packages/l/libgit2/xmake.lua
+++ b/packages/l/libgit2/xmake.lua
@@ -57,7 +57,7 @@ package("libgit2")
         local https = package:config("https")
         if package:is_plat("iphoneos") and https == "openssl" then
             -- TODO: openssl support iphoneos
-            return 
+            return
         end
 
         if https ~= "winhttp" then
@@ -90,6 +90,7 @@ package("libgit2")
             io.replace("cmake/DefaultCFlags.cmake", "/MTd", "", {plain = true})
             io.replace("cmake/DefaultCFlags.cmake", "/MD", "", {plain = true})
             io.replace("cmake/DefaultCFlags.cmake", "/MDd", "", {plain = true})
+            io.replace("cmake/DefaultCFlags.cmake", "/LTCG", "", {plain = true})
 
             io.replace("CMakeLists.txt", "/GL", "", {plain = true})
             if package:version():eq("1.7.1") then
@@ -109,7 +110,7 @@ package("libgit2")
                 if package:is_plat("windows", "mingw", "msys") then
                     table.join2(links, {"ws2_32", "advapi32", "bcrypt"})
                 end
-    
+
                 io.replace("cmake/FindmbedTLS.cmake",
                     [["-L${MBEDTLS_LIBRARY_DIR} -l${MBEDTLS_LIBRARY_FILE} -l${MBEDX509_LIBRARY_FILE} -l${MBEDCRYPTO_LIBRARY_FILE}"]],
                     table.concat(links, " "), {plain = true})


### PR DESCRIPTION
**Verbose Log**
```sh
checkinfo: ...gramdir\core\sandbox\modules\import\core\tool\linker.lua:75: @programdir\modules\core\tools\link.lua:175: git2.lib(repository.obj) : .netmodule ou module MSIL compilé avec /GL trouvé ; redémarrage de l'édition de liens avec /LTCG ; ajoutez 
/LTCG à la ligne de commande de l'édition de liens pour améliorer les performances de l'Éditeur de liens

stack traceback:
    [C]: in function 'error'
    [@programdir\core\base\os.lua:1004]:
    [@programdir\modules\core\tools\link.lua:175]: in function 'catch'
    [@programdir\core\sandbox\modules\try.lua:123]: in function 'try'
    [@programdir\modules\core\tools\link.lua:150]:
    [C]: in function 'xpcall'
    [@programdir\core\base\utils.lua:244]:
    [@programdir\core\tool\linker.lua:232]: in function 'link'
    [...gramdir\core\sandbox\modules\import\core\tool\linker.lua:73]: in function 'link'
    [@programdir\modules\lib\detect\check_cxsnippets.lua:249]:
    [C]: in function 'xpcall'
    [@programdir\core\base\utils.lua:244]: in function 'trycall'
    [@programdir\core\sandbox\modules\try.lua:117]: in function 'try'
    [@programdir\modules\lib\detect\check_cxsnippets.lua:236]:
    [...ake\repositories\xmake-repo\packages\l\libgit2\xmake.lua:156]: in function 'script'
    [...dir\modules\private\action\require\impl\utils\filter.lua:114]: in function 'call'
    [...dir\modules\private\action\require\impl\actions\test.lua:41]:
    [...\modules\private\action\require\impl\actions\install.lua:432]:
    [C]: in function 'xpcall'
    [@programdir\core\base\utils.lua:244]: in function 'trycall'
    [@programdir\core\sandbox\modules\try.lua:117]: in function 'try'
    [...\modules\private\action\require\impl\actions\install.lua:361]:
    [...modules\private\action\require\impl\install_packages.lua:496]: in function 'jobfunc'
    [@programdir\modules\async\runjobs.lua:241]:
    [C]: in function 'xpcall'
    [@programdir\core\base\utils.lua:244]: in function 'trycall'
    [@programdir\core\sandbox\modules\try.lua:117]: in function 'try'
    [@programdir\modules\async\runjobs.lua:223]: in function 'cotask'
    [@programdir\core\base\scheduler.lua:406]:

error: ...ake\repositories\xmake-repo\packages\l\libgit2\xmake.lua:156: ...gramdir\core\sandbox\modules\import\core\tool\linker.lua:75: @programdir\modules\core\tools\link.lua:175: git2.lib(repository.obj) : .netmodule ou module MSIL compilé avec /GL trouvé ; redémarrage de l'édition de liens avec /LTCG ; ajoutez /LTCG à la ligne de commande de l'édition de liens pour améliorer 
les performances de l'Éditeur de liens

stack traceback:
    [C]: in function 'error'
    [@programdir\core\base\os.lua:1004]:
    [@programdir\modules\core\tools\link.lua:175]: in function 'catch'
    [@programdir\core\sandbox\modules\try.lua:123]: in function 'try'
    [@programdir\modules\core\tools\link.lua:150]:
    [C]: in function 'xpcall'
    [@programdir\core\base\utils.lua:244]:
    [@programdir\core\tool\linker.lua:232]: in function 'link'
    [...gramdir\core\sandbox\modules\import\core\tool\linker.lua:73]: in function 'link'
    [@programdir\modules\lib\detect\check_cxsnippets.lua:249]:
    [C]: in function 'xpcall'
    [@programdir\core\base\utils.lua:244]: in function 'trycall'
    [@programdir\core\sandbox\modules\try.lua:117]: in function 'try'
    [@programdir\modules\lib\detect\check_cxsnippets.lua:236]:
    [...ake\repositories\xmake-repo\packages\l\libgit2\xmake.lua:156]: in function 'script'
    [...dir\modules\private\action\require\impl\utils\filter.lua:114]: in function 'call'
    [...dir\modules\private\action\require\impl\actions\test.lua:41]:
    [...\modules\private\action\require\impl\actions\install.lua:432]:
    [C]: in function 'xpcall'
    [@programdir\core\base\utils.lua:244]: in function 'trycall'
    [@programdir\core\sandbox\modules\try.lua:117]: in function 'try'
    [...\modules\private\action\require\impl\actions\install.lua:361]:
    [...modules\private\action\require\impl\install_packages.lua:496]: in function 'jobfunc'
    [@programdir\modules\async\runjobs.lua:241]:
    [C]: in function 'xpcall'
    [@programdir\core\base\utils.lua:244]: in function 'trycall'
    [@programdir\core\sandbox\modules\try.lua:117]: in function 'try'
    [@programdir\modules\async\runjobs.lua:223]: in function 'cotask'
    [@programdir\core\base\scheduler.lua:406]:

  => install libgit2 v1.8.4 .. failed
error: @programdir\core\main.lua:329: @programdir\core\sandbox\modules\import\core\base\task.lua:65: @programdir\modules\async\runjobs.lua:325: ...\modules\private\action\require\impl\actions\install.lua:494: install failed!
stack traceback:
    [C]: in function 'error'
    [@programdir\core\base\os.lua:1004]:
    [...\modules\private\action\require\impl\actions\install.lua:494]: in function 'catch'
    [@programdir\core\sandbox\modules\try.lua:123]: in function 'try'
    [...\modules\private\action\require\impl\actions\install.lua:361]:
    [...modules\private\action\require\impl\install_packages.lua:496]: in function 'jobfunc'
    [@programdir\modules\async\runjobs.lua:241]:

stack traceback:
        [C]: in function 'error'
        @programdir\core\base\os.lua:1004: in function 'base/os.raiselevel'
        (...tail calls...)
        @programdir\core\main.lua:329: in upvalue 'cotask'
        @programdir\core\base\scheduler.lua:406: in function <@programdir\core\base\scheduler.lua:399>
  ```